### PR TITLE
Use globalThis instead of window for globals

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -46,7 +46,7 @@ function handleStatus(response) {
  *  method: Method,
  *  opts?: RequestOptions,
  *  data?: any,
- *  fetchFn?: typeof window.fetch
+ *  fetchFn?: typeof globalThis.fetch
  * }} MetaParams
  */
 
@@ -92,7 +92,7 @@ export class Api {
     const csrfToken = getCookie(this.config.xsrfCookieName);
     const xsrfHeaderName = this.config.xsrfHeaderName ?? 'X-CSRF-TOKEN';
 
-    let fetchFn = window.fetch;
+    let fetchFn = globalThis.fetch;
     let baseURL = opts?.baseURL ?? this.config?.baseURL ?? '';
     let responseType = opts?.responseType ?? this.config.responseType;
 


### PR DESCRIPTION
## Summary
If you try to use this in non-browser runtimes, like node and Cloudflare Workers, you'll get an `Uncaught ReferenceError: window is not defined` error

Use `globalThis` instead of `window` and the code will use the global fetch if it's available; just like in the browser


## Out of scope
There's another blocker for using outside the browser. https://github.com/thepassle/app-tools/blob/630152938fb9d94b4f78c160ddfd089e40625fb3/api/index.js#L1 uses `document`

I worked around this locally by commenting out https://github.com/thepassle/app-tools/blob/399532e22113987436980c6fb5ed0c4721fa1430/api/index.js#L92 and https://github.com/thepassle/app-tools/blob/399532e22113987436980c6fb5ed0c4721fa1430/api/index.js#L101

Perhaps `getCookie` could become a plugin, param, or some other way the consumer could say how to access/manage the cookie?