### PR TITLE
Fixes #9, external nav and nav to custom protocols

### DIFF
--- a/router/index.js
+++ b/router/index.js
@@ -126,9 +126,7 @@ export class Router extends EventTarget {
     const url = new URL(a.href);
 
     if (this.url.href === url.href) return;
-    
     if (url.host !== window.location.host) return;
-    
     if (a.hasAttribute('download') || a.href.includes('mailto:')) return;
 
     const target = a.getAttribute('target');

--- a/router/index.js
+++ b/router/index.js
@@ -142,6 +142,13 @@ export class Router extends EventTarget {
     if (typeof url === 'string') {
       url = new URL(url, this.baseUrl);
     }    
+    
+    // If this a route outside our domain, just navigate away.
+    if (url.host !== window.location.host) {
+      window.location.href = url;
+      return;
+    }
+    
     this.route = this._matchRoute(url) || this._matchRoute(this.fallback);
     log(`Navigating to ${url.pathname}${url.search}`, { context: this.context, route: this.route });
 

--- a/router/index.js
+++ b/router/index.js
@@ -143,7 +143,7 @@ export class Router extends EventTarget {
       url = new URL(url, this.baseUrl);
     }    
     
-    // If this a route outside our domain, just navigate away.
+    // If this is a route outside our domain, just navigate away.
     if (url.host !== window.location.host) {
       window.location.href = url;
       return;

--- a/router/index.js
+++ b/router/index.js
@@ -126,6 +126,9 @@ export class Router extends EventTarget {
     const url = new URL(a.href);
 
     if (this.url.href === url.href) return;
+    
+    if (url.host !== window.location.host) return;
+    
     if (a.hasAttribute('download') || a.href.includes('mailto:')) return;
 
     const target = a.getAttribute('target');
@@ -141,12 +144,6 @@ export class Router extends EventTarget {
   async navigate(url) {
     if (typeof url === 'string') {
       url = new URL(url, this.baseUrl);
-    }    
-    
-    // If this is a route outside our domain, just navigate away.
-    if (url.host !== window.location.host) {
-      window.location.href = url;
-      return;
     }
     
     this.route = this._matchRoute(url) || this._matchRoute(this.fallback);


### PR DESCRIPTION
Navigating to an external link (e.g. https://google.com) previously wouldn't actually navigate to that external link; it would try to match the fallback and navigate to that.

Additionally, navigating to a custom protocol (e.g. x-github-client://...) would throw an error as we tried to pushState() for different origins with the error,

> Uncaught (in promise) DOMException: Failed to execute 'pushState' on 'History': A history state object with URL 'http://...' cannot be created in a document with origin 'http://.../' and URL 'http://...'.
at Router.navigate (http://localhost:5173/node_modules/.vite/deps/@thepassle_app-tools_router__js.js?v=833e0bfe:186:20)

This PR is a small change: if we try to navigate to a different host, we set window.location.href to the desired link.