### PR TITLE
Fixes back #12, back navigation issue

### DIFF
--- a/router/index.js
+++ b/router/index.js
@@ -140,7 +140,7 @@ export class Router extends EventTarget {
    * @param {string | URL} url The URL to navigate to.
    * @param {@param {{
    *    backNav?: boolean
-   *  }} options} options Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
+   *  }} options} options An options object to configure the navigation. The backNav property specifies whether the navigation is a backward navigation, which doesn't push the navigation into browser nav history.
    */
   async navigate(url, options = {}) {
     if (typeof url === 'string') {
@@ -186,7 +186,7 @@ export class Router extends EventTarget {
       }
     }
 
-    if (!options?.backNav) {
+    if (!options.backNav) {
       window.history.pushState(null, '', `${url.pathname}${url.search}`);
     }
     document.title = this.context.title;

--- a/router/index.js
+++ b/router/index.js
@@ -106,7 +106,7 @@ export class Router extends EventTarget {
   }
 
   _onPopState = () => {
-    this.navigate(new URL(window.location.href));
+    this.navigate(new URL(window.location.href), true);
   }
 
   _onAnchorClick = (e) => {
@@ -139,7 +139,7 @@ export class Router extends EventTarget {
   /**
    * @param {string | URL} url 
    */
-  async navigate(url) {
+  async navigate(url, isBackNav) {
     if (typeof url === 'string') {
       url = new URL(url, this.baseUrl);
     }
@@ -183,7 +183,9 @@ export class Router extends EventTarget {
       }
     }
 
-    window.history.pushState(null, '', `${url.pathname}${url.search}`);
+    if (!isBackNav) {
+      window.history.pushState(null, '', `${url.pathname}${url.search}`);
+    }
     document.title = this.context.title;
     this._notifyUrlChanged();
 

--- a/router/index.js
+++ b/router/index.js
@@ -137,7 +137,8 @@ export class Router extends EventTarget {
   }
 
   /**
-   * @param {string | URL} url 
+   * @param {string | URL} url The URL to navigate to.
+   * @param {boolean | null | undefined} isBackNav Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
    */
   async navigate(url, isBackNav) {
     if (typeof url === 'string') {

--- a/router/index.js
+++ b/router/index.js
@@ -106,7 +106,7 @@ export class Router extends EventTarget {
   }
 
   _onPopState = () => {
-    this.navigate(new URL(window.location.href), true);
+    this.navigate(new URL(window.location.href), { backNav: true });
   }
 
   _onAnchorClick = (e) => {
@@ -138,9 +138,11 @@ export class Router extends EventTarget {
 
   /**
    * @param {string | URL} url The URL to navigate to.
-   * @param {boolean | null | undefined} isBackNav Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
+   * @param {@param {{
+   *    backNav?: boolean
+   *  } | null | undefined } options} options Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
    */
-  async navigate(url, isBackNav) {
+  async navigate(url, options) {
     if (typeof url === 'string') {
       url = new URL(url, this.baseUrl);
     }
@@ -184,7 +186,7 @@ export class Router extends EventTarget {
       }
     }
 
-    if (!isBackNav) {
+    if (!options?.backNav) {
       window.history.pushState(null, '', `${url.pathname}${url.search}`);
     }
     document.title = this.context.title;

--- a/router/index.js
+++ b/router/index.js
@@ -140,9 +140,9 @@ export class Router extends EventTarget {
    * @param {string | URL} url The URL to navigate to.
    * @param {@param {{
    *    backNav?: boolean
-   *  } | null | undefined } options} options Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
+   *  }} options} options Whether the navigation is a backward navigation (e.g. clicking the browser back button.) Backward navigations won't push a new URL into the browser history.
    */
-  async navigate(url, options) {
+  async navigate(url, options = {}) {
     if (typeof url === 'string') {
       url = new URL(url, this.baseUrl);
     }


### PR DESCRIPTION
This PR fixes #12, backward navigation bug, by skipping `pushState` when we navigate backward.