### PR TITLE
Redirect allows for context

### DIFF
--- a/router/README.md
+++ b/router/README.md
@@ -305,6 +305,13 @@ const router = new Router({
         redirect('/404'),
       ],
     },
+    {
+      path: '/legacy/detail/:product',
+      title: 'Foo',
+      plugins: [
+        redirect(context => '/detail/${context.params.product}'),
+      ],
+    },
   ]
 });
 ```

--- a/router/plugins/redirect.js
+++ b/router/plugins/redirect.js
@@ -1,13 +1,13 @@
 /**
- * @param {string} path 
+ * @param {string|((context:(import('../index.js').Context) => string)} path
  * @returns {import('../index.js').Plugin}
  */
 export function redirect(path) {
   return {
     name: 'redirect',
-    shouldNavigate: () => ({
+    shouldNavigate: (context) => ({
       condition: () => false,
-      redirect: path
+      redirect: typeof path === 'function' ? path(context) : path
     })
   }
 }


### PR DESCRIPTION
Redirect plugin accepts a string or function, allowing the redirect to use path params.

Usage:
```js
redirect((context) => `/foo/${context.params.name}`);
```