### PR TITLE
Router bug fixes

### DIFF
--- a/router/types.ts
+++ b/router/types.ts
@@ -4,12 +4,14 @@ export interface Config {
   routes: RouteDefinition[];
 }
 
+export interface ShouldNavigateResult {
+  redirect: string;
+  condition: (() => boolean) | (() => Promise<boolean>);
+}
+
 export interface Plugin {
   name: string;
-  shouldNavigate?: (context: Context) => {
-    redirect: string,
-    condition: () => boolean | (() => Promise<Boolean>),
-  };
+  shouldNavigate?: ((context: Context) => ShouldNavigateResult) | ((context: Context) => Promise<ShouldNavigateResult>);
   beforeNavigation?: (context: Context) => void;
   afterNavigation?: (context: Context) => void;
 }

--- a/types/router/types.d.ts
+++ b/types/router/types.d.ts
@@ -3,12 +3,13 @@ export interface Config {
     plugins?: Plugin[];
     routes: RouteDefinition[];
 }
+export interface ShouldNavigateResult {
+    redirect: string;
+    condition: (() => boolean) | (() => Promise<boolean>);
+}
 export interface Plugin {
     name: string;
-    shouldNavigate?: (context: Context) => {
-        redirect: string;
-        condition: () => boolean | (() => Promise<Boolean>);
-    };
+    shouldNavigate?: ((context: Context) => ShouldNavigateResult) | ((context: Context) => Promise<ShouldNavigateResult>);
     beforeNavigation?: (context: Context) => void;
     afterNavigation?: (context: Context) => void;
 }


### PR DESCRIPTION
Hi - when using the router we ran into a few issues that should be fixed by this PR:

* Fix type of `shouldNavigate()` to allow for it to be async (the code already supports this)
* Fix type of `condition` to properly allow for both sync and async boolean returns (missing parens around the sync case)
* Make multiple redirects work properly by switching to the new route's plugins after a redirect (in the original code, reassigning the `plugins` array doesn't actually change the array used by the for loop)

Thanks!