### PR TITLE
Update Router.route type def

### DIFF
--- a/types/router/index.d.ts
+++ b/types/router/index.d.ts
@@ -60,7 +60,7 @@ export class Router extends EventTarget {
         backNav?: boolean;
         replace?: boolean;
     }): Promise<void>;
-    route: import("./types.js").Route;
+    route?: import("./types.js").Route;
 }
 export type Plugin = import('./types.js').Plugin;
 export type Context = import('./types.js').Context;


### PR DESCRIPTION
A Router's `.route` property is initially undefined, and not available until after the first microtask after instantiation.

```js
const router = new Router()

console.log(router.route) // undefined

queueMicrotask(() => {
  console.log(router.route) // Route
})
```

`.route` is set upon first `navigate()` call, here:

https://github.com/thepassle/app-tools/blob/8c514c4ba2eb879e43d96ea4dfbbe9a0680197ac/router/index.js#L209

First `navigate()` happens here:

https://github.com/thepassle/app-tools/blob/8c514c4ba2eb879e43d96ea4dfbbe9a0680197ac/router/index.js#L53-L55